### PR TITLE
업로드 완료 페이지 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,8 @@ import NavigationBar from "./components/NavigationBar";
 import TestPage from "./pages/TestPage/TestPage";
 import SettingPage from "./pages/SettingPage/SettingPage";
 import MyDetailPage from "./pages/MyDetailpage/MyDetailPage";
+import UploadPage from "./pages/UploadPage/UploadPage";
+import UploadDonePage from "./pages/UploadPage/UploadDonePage";
 
 function App() {
   return (
@@ -20,6 +22,8 @@ function App() {
         </Route>
         <Route path="/profile/setting" element={<SettingPage />}></Route>
         <Route path="/test" element={<TestPage />}></Route>
+        <Route path="/upload" element={<UploadPage />}></Route>
+        <Route path="/uploadDone" element={<UploadDonePage />}></Route>
       </Routes>
       <NavigationBar />
     </BrowserRouter>

--- a/src/components/ModalExtraButton.jsx
+++ b/src/components/ModalExtraButton.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { styled } from "styled-components";
+
+const Button = styled.button`
+  font-family: "Pretendard Variable", Pretendard, -apple-system,
+    BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI",
+    "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  cursor: pointer;
+  width: ${(props) => (props.$isLong ? "214px" : "80px")};
+  height: 44px;
+  border: none;
+  border-radius: 8px;
+  outline: none;
+  color: ${(props) =>
+    props.$isTextBlack ? props.theme.black : props.theme.white};
+  background-color: ${(props) => props.$bgColor};
+`;
+
+const Layout = styled.div`
+  height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Icon = styled.img`
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+`;
+
+const Text = styled.div`
+  height: 19px;
+  font-size: 14px;
+  line-height: 1.4;
+`;
+
+const ModalExtraButton = ({
+  isLong = false,
+  bgColor,
+  isTextBlack = false,
+  onClick,
+  iconSrc,
+  text,
+}) => {
+  return (
+    <Button
+      $isLong={isLong}
+      $bgColor={bgColor}
+      $isTextBlack={isTextBlack}
+      onClick={onClick}
+    >
+      <Layout>
+        {iconSrc && <Icon src={iconSrc} />}
+        <Text>{text}</Text>
+      </Layout>
+    </Button>
+  );
+};
+
+export default ModalExtraButton;

--- a/src/pages/UploadPage/UploadDonePage.jsx
+++ b/src/pages/UploadPage/UploadDonePage.jsx
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import Layout from "../../components/Layout";
+import styled from "styled-components";
+import ModalExtraButton from "../../components/ModalExtraButton";
+import theme from "../../theme";
+
+import { useNavigate } from "react-router-dom";
+
+const Container = styled.div`
+  width: 342px;
+  height: 607px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  background-color: ${(props) => props.theme.gray};
+  border-radius: 10px;
+`;
+
+const Text = styled.p`
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 28px;
+`;
+
+const ImageBox = styled.div`
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 8px;
+`;
+
+const ButtonBox = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 20px;
+`;
+
+const UploadDonePage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Layout>
+      <Container>
+        <Text>업로드 완료!</Text>
+        <ImageBox>{/* image, nickName, hashTags */}</ImageBox>
+        <ButtonBox>
+          <ModalExtraButton
+            isLong
+            isTextBlack
+            onClick={() => {
+              console.log("스토리 공유!");
+            }}
+            iconSrc="/icons/instagram.png"
+            bgColor={theme.white}
+            text="스토리 공유하기"
+          />
+          <ModalExtraButton
+            isLong={false}
+            isTextBlack
+            onClick={() => {
+              navigate("/");
+            }}
+            bgColor={theme.white}
+            text="확인"
+          />
+        </ButtonBox>
+      </Container>
+    </Layout>
+  );
+};
+
+export default UploadDonePage;

--- a/src/pages/UploadPage/UploadPage.jsx
+++ b/src/pages/UploadPage/UploadPage.jsx
@@ -5,6 +5,7 @@ import ModalButton from "../../components/ModalButton";
 import theme from "../../theme";
 import Post from "../../components/Post";
 import PostInfos from "../../components/PostInfos";
+import { useNavigate } from "react-router-dom";
 
 const Container = styled.div`
   width: 310px;
@@ -72,8 +73,10 @@ const isEmptyValue = (value) => {
 
 const UploadPage = () => {
   const [name, setName] = useState("");
+
   const [inputHashtag, setInputHashtag] = useState("");
   const [hashtags, setHashtags] = useState([]);
+  const navigate = useNavigate();
 
   const handleNameChange = (e) => {
     const newName = e.target.value;
@@ -146,6 +149,7 @@ const UploadPage = () => {
     }
     console.log("업로드 API 요청", name.trim());
     console.log("업로드 API 요청", hashtags);
+    navigate("/uploadDone");
   };
 
   const handleCancelClick = (e) => {

--- a/src/theme.js
+++ b/src/theme.js
@@ -5,6 +5,7 @@ const theme = {
   red: "#fe2020",
   pink: "#ff3a75",
   yellow: "#fee703",
+  gray: "#303134",
   icon: {
     white: "rgba(255, 255, 255, 0.01)",
     hover: "rgba(255, 255, 255, 0.1)",


### PR DESCRIPTION
### 업로드 완료 페이지(UploadDonePage.jsx) 구현

- theme에 gray 컬러를 추가했습니다.
- path를  /uploadDone 으로 설정했습니다.
- 아래 화면처럼 일단 ImageBox(이미지, 닉네임, 해시태그 정보가 들어가야함)가 비어있는 상태로 구현했습니다!
- 차주에 리팩토링 및 recoil 적용하여 PR 하겠습니다!
<img width="331" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team14_FE/assets/64532143/2751f7bb-025d-4ac8-9868-f31685afead3">

### ModalButton 재사용
- 버튼의 크기가 기존 ModalButton 컴포넌트의 long 기준과 달라서 ModalExtraButton 컴포넌트를 추가로 생성해보았습니다. 기존 ModalButton와 차이는 버튼 크기뿐이라서 코드가 중복되는데 혹시 좋은 아이디어 있을까요?


